### PR TITLE
💪 「.フォルダー」（例: .terraform）をTerraformファイル自動検索から除く

### DIFF
--- a/lint/entrypoint.sh
+++ b/lint/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 if $AUTO_SEARCH_TF_DIR ; then
-    WORKING_DIRS=$(sh -c 'find . -type f -name "*.tf" -exec dirname {} \;|sort -u'  2>&1)
+    WORKING_DIRS=$(sh -c 'find . -type f -name "*.tf" -not -path "**/.*/*" -exec dirname {} \;|sort -u'  2>&1)
 else
     WORKING_DIRS="${TF_ACTION_WORKING_DIR:-.}"
 fi

--- a/validate/entrypoint.sh
+++ b/validate/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 set -x 
 
 if $AUTO_SEARCH_TF_DIR ; then
-    WORKING_DIRS=$(sh -c 'find . -type f -name "*.tf" -exec dirname {} \;|sort -u'  2>&1)
+    WORKING_DIRS=$(sh -c 'find . -type f -name "*.tf" -not -path "**/.*/*" -exec dirname {} \;|sort -u'  2>&1)
 else
     WORKING_DIRS="${TF_ACTION_WORKING_DIR:-.}"
 fi


### PR DESCRIPTION
・深くファイルを洗い出すとエラーが発生する場合がありますので無視してもいいものなので無視するようにしました